### PR TITLE
fix build issue with ngModule setup

### DIFF
--- a/projects/ngx-hotjar/src/lib/initializers/hotjar.initializer.ts
+++ b/projects/ngx-hotjar/src/lib/initializers/hotjar.initializer.ts
@@ -1,4 +1,4 @@
-import { APP_INITIALIZER, Provider } from '@angular/core';
+import { APP_INITIALIZER, Provider, isDevMode } from '@angular/core';
 import { IHotjarSettings } from '../interfaces/i-hotjar-settings';
 import { NGX_HOTJAR_SETTINGS_TOKEN } from '../tokens/ngx-hotjar-settings.token';
 
@@ -15,8 +15,12 @@ export function HotjarInitializer(
   $settings: IHotjarSettings
 ) {
   return async () => {
-    if ($settings.trackingCode === '') {
-      console.error('Empty tracking-code. Maybe you forget to inject NGX_HOTJAT_SETTINGS_TOKEN on providers list');
+    if (!$settings.trackingCode) {
+      if (!isDevMode()) {
+        console.error('Empty tracking code for Hotjar. Make sure to provide one when initializing NgxHotjarModule.');
+      }
+
+      return;
     }
 
     (function(h: any, o: any, t: any, j: any, a?: any, r?: any) {

--- a/projects/ngx-hotjar/src/lib/ngx-hotjar.module.ts
+++ b/projects/ngx-hotjar/src/lib/ngx-hotjar.module.ts
@@ -12,31 +12,19 @@ import { NGX_HOTJAR_SETTINGS_TOKEN } from './tokens/ngx-hotjar-settings.token';
   ]
 })
 export class NgxHotjarModule {
-  static forRoot(trackingCode: string, version: number = 6, force: boolean = false): ModuleWithProviders {
-
-    // if (!domain) {
-    //   domain = `${document.location.protocol}://${document.location.hostname}`;
-    // }
-
-    const providers: Provider[] = [];
-
-    if (!isDevMode() || force) {
-      providers.push(NGX_HOTJAR_INITIALIZER_PROVIDER);
-
-      if (trackingCode) {
-        providers.unshift({
+  static forRoot(trackingCode: string, version: number = 6): ModuleWithProviders {
+    return {
+      ngModule: NgxHotjarModule,
+      providers: [
+        {
           provide: NGX_HOTJAR_SETTINGS_TOKEN,
           useValue: {
             trackingCode: trackingCode,
             version: version
           }
-        });
-      }
-    }
-
-    return {
-      ngModule: NgxHotjarModule,
-      providers: providers
+        },
+        NGX_HOTJAR_INITIALIZER_PROVIDER,
+      ]
     };
   }
 }


### PR DESCRIPTION
Thanks for making this. I went looking for a Hotjar module to include in my Angular project, and I found that you only started this 6 days ago! I ran into an issue when building my project for production, and I thought I'd open a PR to fix it.

---

For some bizarre reason, the `forRoot` function can’t have any code before the return statement, or Angular throws this error:

```
ERROR in Error during template compile of 'AppModule'
  Function calls are not supported in decorators but 'NgxHotjarModule' was called.
```

I’ve also removed the `force` configuration, as the presence of a tracking code should be sufficient to decide whether to initialise Hotjar tracking or not. If you insist on having the `force` config though, I could add it to `IHotjarSettings`.