### PR TITLE
Adding support for tag recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ class component implements OnInit {
 }
 ```
 
+## Tag recordings
+
+```ts
+class component implements OnInit {
+  constructor(
+    protected $hotjar: NgxHotjarService
+  ) {}
+
+  ngOnInit() {
+    this.$hotjar.tagRecording(['tag1', 'tag2']);
+  }
+}
+```
+
 ## Trigger Page Navigation
 
 ```ts

--- a/projects/ngx-hotjar/src/lib/services/ngx-hotjar.service.ts
+++ b/projects/ngx-hotjar/src/lib/services/ngx-hotjar.service.ts
@@ -36,6 +36,19 @@ export class NgxHotjarService {
   }
 
   /**
+   * Allows you to tag recordings on Hotjar of all visitors passing through a page.
+   *
+   * @param path tags
+   */
+  tagRecording(path: string[]): void {
+    try {
+      hj('tagRecording', path);
+    } catch (err) {
+      this.error(err);
+    }
+  }
+
+  /**
    * This option is available in case you need to set up page change tracking manually
    * within your app's router.
    *


### PR DESCRIPTION
Hey @maxandriani! As outlined in #2, I've went ahead and added the code required to tag recordings in Hotjar as per the following [documentation](https://help.hotjar.com/hc/en-us/articles/115011819488-How-to-Tag-your-Hotjar-Recordings):

> To tag a Recording, add this JavaScript code:
> ```
> hj('tagRecording', ['tag1', 'tag2']);
> ```
> Doing so will cause all Recordings of visitors who pass-through this page to include the two tags "tag1" and "tag2".



Do let me know if I'm missing anything, cheers!